### PR TITLE
Update developing-osgi-plugins-for-liferay-intro.markdown

### DIFF
--- a/develop/tutorials/articles/osgi/developing-osgi-plugins-for-liferay-intro.markdown
+++ b/develop/tutorials/articles/osgi/developing-osgi-plugins-for-liferay-intro.markdown
@@ -46,7 +46,7 @@ files:
 - `build.xml`
 
 Bnd is a tool that makes it easy to create OSGi bundles. See
-[www.aquite.biz/Bnd/Bnd](www.aqute.biz/Bnd/Bnd) for details about what you can
+[www.aquite.biz/Bnd/Bnd](http://www.aqute.biz/Bnd/Bnd) for details about what you can
 specify in your `bnd.bnd` file. Basically, your `bnd.bnd` file contains
 instructions about dependency management and how to create your OSGi bundle's
 JAR file.


### PR DESCRIPTION
The link to www.aqute.biz was not referenced with http:// so it was treated as an inline link instead of external.
