### PR TITLE
Pass argument into message tag

### DIFF
--- a/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
+++ b/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
@@ -68,7 +68,7 @@ to the `welcome-x` language key in the "My Greeting" portlet.
 3.  Replace the current welcome message tag and exclamation point,
     `<liferay-ui:message key="welcome" />!`, in the JSP with the following:
 
-        <liferay-ui:message key="welcome-x" /> <%= user.getScreenName() %>
+        <liferay-ui:message key="welcome-x" arguments="<%= user.getScreenName() %>"/> 
 
 When you refesh your page, your "My Greeting" portlet greets you by your screen
 name!


### PR DESCRIPTION
The text sets up an example of passing a variable into a message tag, but ultimately just rendered the variable after the message. This corrects that. My source for the syntax is: https://www.liferay.com/community/forums/-/message_boards/message/25786855