### PR TITLE
Update 01-configuring-your-permissions-scheme.markdown

### DIFF
--- a/develop/learning-paths/mvc/articles/04-setting-permissions/01-configuring-your-permissions-scheme.markdown
+++ b/develop/learning-paths/mvc/articles/04-setting-permissions/01-configuring-your-permissions-scheme.markdown
@@ -56,7 +56,7 @@ Next, you'll create the file itself:
 
         <?xml version="1.0"?>
         <!DOCTYPE resource-action-mapping PUBLIC "-//Liferay//DTD Resource Action Mapping 6.2.0//EN"
-    	"http://www.liferay.com/dtd/liferay-resource-action- mapping_6_2_0.dtd">
+    	"http://www.liferay.com/dtd/liferay-resource-action-mapping_6_2_0.dtd">
 
 If you have a copy of Liferay's source code, you'll find the DTD for this file
 in the `definitions` folder. The DTD is fully documented and explains every tag


### PR DESCRIPTION
Removed an extra space from the DOCTYPE declaration at the top of default.xml