### PR TITLE
Update 03-using-maven-from-liferay-ide.markdown

### DIFF
--- a/develop/tutorials/articles/04-maven/03-using-maven-from-liferay-ide.markdown
+++ b/develop/tutorials/articles/04-maven/03-using-maven-from-liferay-ide.markdown
@@ -73,7 +73,7 @@ Liferay Maven project. Note, you don't need to have an existing Liferay Maven
 project to continue. However, if you'd like to create a new Liferay Maven
 portlet project in the IDE before proceeding, you can do so by following
 instructions in the the tutorial
-[Developing Liferay Portlets with Maven](/tutorials/-/knowledge_base/6-2/creating-liferay-portlets-with-maven).
+[Developing Liferay Portlets with Maven](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-portlets-with-maven).
 Alternatively, you can import an existing Maven project by navigating to *File*
 &rarr; *Import* &rarr; *Maven* and selecting the location of Maven project's
 source code. 
@@ -99,7 +99,7 @@ project's properties. The configurator detects invalid properties and reports
 them as errors in the IDE's POM editor. There are a list of key properties that
 your project must specify in order for it to become a valid Liferay IDE project.
 The
-[Using Maven Parent Plugin Projects](/tutorials/-/knowledge_base/6-2/using-maven-parent-plugin-projects)
+[Using Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-maven-parent-plugin-projects)
 tutorial identifies these properties and explains how they are used. 
 
 Liferay IDE's Quick Fix features provide two options for resolving missing
@@ -164,7 +164,7 @@ parent `pom.xml` overrides the user `settings.xml` file, and the user
 Note that if a *profile* is active from your user `settings.xml`, its values 
 override your properties in a POM. If you'd like to specify the properties in a
 POM, see the
-[Using Liferay Maven Parent Plugin Projects](/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
+[Using Liferay Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
 tutorial for more details. 
 
 Here's an example of what a Maven profile looks like inside the `settings.xml`


### PR DESCRIPTION
Three of the links embedded in the article aren't working.  It lookls like the relative URL needs to start with /develop before the /tutorial.