### PR TITLE
Correct link at bottom of page for Plugins SDK

### DIFF
--- a/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
+++ b/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
@@ -298,7 +298,7 @@ name of the person submitting the entry and one for the entry itself.
 1. From the *Liferay AUI Taglib* snippet category, drag the *form* snippet to
 your page. 
 
-2. For the `action` attribute, supply *addEntryURL*, which is the action URL you
+2. For the `action` attribute, supply *<% addEntryURL %>*, which is the action URL you
 just created. 
 
 3. For the `name` attribute, give your form the name *<portlet:namespace />fm*.

--- a/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
+++ b/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
@@ -298,7 +298,7 @@ name of the person submitting the entry and one for the entry itself.
 1. From the *Liferay AUI Taglib* snippet category, drag the *form* snippet to
 your page. 
 
-2. For the `action` attribute, supply *<% addEntryURL %>*, which is the action URL you
+2. For the `action` attribute, supply *<%= addEntryURL %>*, which is the action URL you
 just created. 
 
 3. For the `name` attribute, give your form the name *<portlet:namespace />fm*.

--- a/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
+++ b/develop/learning-paths/mvc/articles/02-beginning-liferay-development/03-writing-your-first-liferay-application.markdown
@@ -728,7 +728,7 @@ interest you.
 
 Here are more tutorials that you may find interesting:
 
-[Developing Plugins with the Plugins SDK](/develop/tutorials/knowledge_base/6-2/plugins-sdk)
+[Developing Plugins with the Plugins SDK](/develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
 
 [Developing Plugins with Maven](/develop/tutorials/-/knowledge_base/6-2/maven)
 


### PR DESCRIPTION
The link at the bottom of the page to the Plugins SDK is missing a dash.