### PR TITLE
web content instance -> web content article

### DIFF
--- a/discover/portal/articles/02-web-experience-management/04-publishing-content-dynamically/04-publishing-assets.markdown
+++ b/discover/portal/articles/02-web-experience-management/04-publishing-content-dynamically/04-publishing-assets.markdown
@@ -422,7 +422,7 @@ a Web Content Display application. Click the *Add* button, enter a title and
 some content, click on *Display Page* at the right, and select the Display Page
 you just created. Then click *Publish*.
 
-![Figure 5: You can select a display page for a web content instance when creating or editing one.](../../../images/web-content-display-page.png)
+![Figure 5: You can select a display page for a web content article when creating or editing one.](../../../images/web-content-display-page.png)
 
 In the Asset Publisher of the *My Web Content Display Page*, click the *Read
 More* link to display the full content. Notice that the canonical URL for


### PR DESCRIPTION
proposing to change figure 5 description: There's no "web content instance", it's a "web content article" that's being referred to. @codyhoag what do you think?