### PR TITLE
Discontinue use of $TOMCAT_HOME in favor of $CATALINA_*

### DIFF
--- a/discover/deployment/articles/01-installing-liferay/04-installing-liferay-on-tomcat.markdown
+++ b/discover/deployment/articles/01-installing-liferay/04-installing-liferay-on-tomcat.markdown
@@ -20,8 +20,12 @@ You'll see the term *Liferay Home* used in this installation guide. *Liferay
 Home* refers to the folder containing your Tomcat server folder. When Liferay
 is installed on Tomcat, the Liferay Home folder contains the Tomcat server
 folder as well as `data`, `deploy`, `license`, and `osgi` folders. You'll also
-see the term `$TOMCAT_HOME` used in this guide. `$TOMCAT_HOME` refers to your
-Tomcat server folder. This folder is usually named `tomcat-[version]` or
+see the terms `$CATALINA_HOME` and `$CATALINA_BASE` used in this guide. 
+`$CATALINA_BASE` refers to the folder that contains tomcat's binaries, while 
+`$CATALINA_HOME` refers to the folder that contains your configurations - just 
+as you're used to from tomcat's generic installation. If you download a Liferay 
+Tomcat-bundle, both refer to the same directory (just as with a standard tomcat 
+installation). This folder is usually named `tomcat-[version]` or 
 `apache-tomcat-[version]`.
 
 ## Installing Liferay Dependencies [](id=installing-liferay-dependencies)
@@ -36,13 +40,13 @@ third-parties, as described below.
    bundle to your Tomcat server as you manually install Liferay.
 
 2. If you have a Liferay Tomcat bundle, copy all the JARs from your bundle's
-   `$TOMCAT_HOME/lib/ext` folder to your application server's
-   `$TOMCAT_HOME/lib/ext` folder. If the `$TOMCAT_HOME/lib/ext` folder doesn't
+   $`CATALINA_BASE/lib/ext` folder to your application server's
+   `$CATALINA_BASE/lib/ext` folder. If the `$CATALINA_BASE/lib/ext` folder doesn't
    exist on your application server, create it. If you don't have a Liferay
    Tomcat bundle, you'll have to individually download the JARs listed below.
 
     Here's a list of the JARs that you need to copy or download to your
-    `$TOMCAT_HOME/lib/ext` folder:
+    `$CATALINA_BASE/lib/ext` folder:
 
     - `activation.jar` - [http://www.oracle.com/technetwork/java/jaf11-139815.html](http://www.oracle.com/technetwork/java/jaf11-139815.html)
     - `ccpp.jar` - [http://mvnrepository.com/artifact/javax.ccpp/ccpp/1.0](http://mvnrepository.com/artifact/javax.ccpp/ccpp/1.0)
@@ -63,7 +67,7 @@ third-parties, as described below.
 3. Make sure that Tomcat can access the JDBC driver for your database. The list
    of JARs above includes `mysql.jar` and `postgresql.jar`. If you're using a
    database whose JDBC driver is not included in the list above, download the
-   driver and copy it to your `$TOMCAT_HOME/lib/ext` folder.
+   driver and copy it to your `$CATALINA_BASE/lib/ext` folder.
 
 4. Liferay includes an OSGi runtime. Extract the OSGi ZIP file that you
    downloaded and copy the `osgi` folder to your Liferay Home folder. The
@@ -76,16 +80,8 @@ third-parties, as described below.
 Next, you need to configure Tomcat for running Liferay.
 
 1. If you're working with a bundle, copy the `setenv.bat` and `setenv.sh` files
-   from your bundle to your `$TOMCAT_HOME/bin` folder. If not, create these
+   from your bundle to your `$CATALINA_BASE/bin` folder. If not, create these
    files. `setenv.bat` looks like this:
-
-        if exist "%CATALINA_HOME%/jre1.6.0_20/win" (
-            if not "%JAVA_HOME%" == "" (
-                set JAVA_HOME=
-            )
-
-            set "JRE_HOME=%CATALINA_HOME%/jre1.6.0_20/win"
-        )
 
         set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true  -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=384m"
 
@@ -97,7 +93,7 @@ These files set a number of JVM options for Catalina. Catalina is Tomcat's
 servlet container.
 
 2. If you're working with a bundle, copy the
-   `$TOMCAT_HOME/conf/Catalina/localhost/ROOT.xml` file from your bundle to the
+   `$CATALINA_BASE/conf/Catalina/localhost/ROOT.xml` file from your bundle to the
    corresponding location in your application server. If not, create this file.
    The `ROOT.xml` file creates a web application context for Liferay.
    `ROOT.xml` looks like this:
@@ -133,23 +129,23 @@ servlet container.
     disabling sessions entirely.
 
 3. Next, you should make sure that the libraries you copied to
-   `$TOMCAT_HOME/lib/ext` are loaded when you start your server. If you're
-   working with a bundle, copy the `$TOMCAT_HOME/conf/catalina.properties` file
+   `$CATALINA_BASE/lib/ext` are loaded when you start your server. If you're
+   working with a bundle, copy the `$CATALINA_BASE/conf/catalina.properties` file
    from your bundle to your server. If not, open
-   `$TOMCAT_HOME/conf/catalina.properties` and replace the line
+   `$CATALINA_BASE/conf/catalina.properties` and replace the line
 
         common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar
 
     with this one:
 
-        common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar,${catalina.home}/lib/ext,${catalina.home}/lib/ext/*.jar
+        common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar,${catalina.home}/lib/ext,${catalina.base}/lib/ext/*.jar
 
     This allows Catalina to access the JARs that you copied to
-    `$TOMCAT_HOME/lib/ext`.
+    `$CATALINA_BASE/lib/ext`.
 
 4. If you're working with a bundle, copy the
-   `$TOMCAT_HOME/conf/catalina.policy` file from your bundle to your server. If
-   not, just replace the contents of the `$TOMCAT_HOME/conf/catalina.policy`
+   `$CATALINA_BASE/conf/catalina.policy` file from your bundle to your server. If
+   not, just replace the contents of the `$CATALINA_BASE/conf/catalina.policy`
    file with this:
 
         grant {
@@ -158,13 +154,13 @@ servlet container.
 
     If you want to enable PACL for Liferay, you have to enable Tomcat's
     security manager and instruct Catalina to use the
-    `$TOMCAT_HOME/conf/catalina.policy` file. See the Enabling PACL section for
+    `$CATALINA_BASE/conf/catalina.policy` file. See the Enabling PACL section for
     more information.
 
 5. Next, you should make sure that UTF-8 URI encoding is used consistently. If
-   you're working with a bundle, copy the `$TOMCAT_HOME/conf/server.xml` file
+   you're working with a bundle, copy the `$CATALINA_BASE/conf/server.xml` file
    to your server. If not, you can simply make a few edits to `server.xml`.
-   Edit your `$TOMCAT_HOME/conf/server.xml` file and add the attribute
+   Edit your `$CATALINA_BASE/conf/server.xml` file and add the attribute
    `URIEncoding="UTF-8"` wherever you see `redirectPort=8443`, in the
    definition of your connectors (HTTP and AJP). For example:
 
@@ -186,8 +182,8 @@ servlet container.
                    connectionTimeout="20000"
                    redirectPort="8443" URIEncoding="UTF-8" />
 
-6. If you're on Unix, Linux, or Mac OS, navigate to your `$TOMCAT_HOME/bin`
-   folder and run the following command
+6. If you're on Unix, Linux, or Mac OS, navigate to your `$CATALINA_HOME/bin` 
+   and `$CATALINA_BASE/bin` folder(s) and run the following command
 
         chmod a+x *.sh
 
@@ -206,7 +202,7 @@ If you want Tomcat to manage your data source, use this procedure:
    on a different machine, make sure it's accessible from your Liferay machine.
 
 2. Add your data source as a resource in the context of your web application
-   specified in `$TOMCAT_HOME/conf/Catalina/localhost/ROOT.xml`:
+   specified in `$CATALINA_BASE/conf/Catalina/localhost/ROOT.xml`:
 
         <Context...>
             <Resource
@@ -304,14 +300,14 @@ To enable PACL, you need to enable Tomcat's security manager. In the Tomcat
 Configuration section above, you already added the required permissions to the
 Tomcat policy configuration file, `catalina.policy`.
 
-- Edit your `$TOMCAT_HOME/bin/setenv.sh` (if on Linux, Unix, or Mac OS) or
+- Edit your `$CATALINA_BASE/bin/setenv.sh` (if on Linux, Unix, or Mac OS) or
   `setenv.bat` (if on Windows) and enable the security manager by inserting the
   following code into the `CATALINA_OPTS` variable (inside the quotation
   marks):
 
     `-Djava.security.manager -Djava.security.policy=$CATALINA_BASE/conf/catalina.policy`
 
-- Check that your `$TOMCAT_HOME/conf/catalina.policy` file specifies the
+- Check that your `$CATALINA_BASE/conf/catalina.policy` file specifies the
   required permissions (you should have already addressed this in the
   Configuring Tomcat section):
 
@@ -469,17 +465,20 @@ section.
 Now you're ready to deploy Liferay using your Liferay WAR file.
 
 1. If you are manually installing Liferay on a clean Tomcat server, delete the
-   contents of the `$TOMCAT_HOME/webapps/ROOT` directory. This removes the default
+   contents of the `$CATALINA_BASE/webapps/ROOT` directory. This removes the default
    Tomcat home page.
 
-2. Extract the Liferay `.war` file to `$TOMCAT_HOME/webapps/ROOT`.
+2. Extract the Liferay `.war` file to `$CATALINA_BASE/webapps/ROOT`. Double check 
+   that the `.war` file content is indeed unpacked in that folder: You should now 
+   have a folder `$CATALINA_BASE/webapps/ROOT/WEB-INF` (among others, of course).
 
     Now it's time to launch Liferay Portal on Tomcat!
 
-3. Start Tomcat by navigating to `$TOMCAT_HOME/bin` and executing `./startup.sh`
+3. Start Tomcat by navigating to `$CATALINA_HOME/bin` and executing `./startup.sh`
    or `startup.bat`. Alternatively, you can use `./catalina.sh run` or
    `catalina.bat run`. Using one of the latter commands makes your terminal or
    command prompt tail Liferay's log file. This can be useful if you want to
-   see the startup activities performed by Liferay.
+   see the startup activities performed by Liferay or debug reasons why the server
+   doesn't start.
 
 Congratulations on successfully installing and deploying Liferay on Tomcat!


### PR DESCRIPTION
Change directory names from $TOMCAT_HOME to $CATALINA_HOME and $CATALINA_BASE to be synchronized with tomcat's documentation and naming conventions. Great documentation for the difference of both variables (well, mostly they're refering to the same directory anyway) is in tomcat's RUNNING.txt, which is present in every tomcat installation.

In the beginning I actually made a mistake and described CATALINA_BASE and CATALINA_HOME the other way around - but I can't add another commit through this interface... Please edit the beginning and have it rather sound

`$CATALINA_BASE` refers to the folder that contains your configuration, while 
`$CATALINA_HOME` refers to the folder that contains tomcat's binaries

Sorry.
