### PR TITLE
Update 02-fragment-template.markdown

### DIFF
--- a/develop/tutorials/articles/100-tooling/01-blade-cli/02-creating-modules-with-blade-cli/02-fragment-template.markdown
+++ b/develop/tutorials/articles/100-tooling/01-blade-cli/02-creating-modules-with-blade-cli/02-fragment-template.markdown
@@ -6,7 +6,7 @@ following:
 
     blade create -t fragment -h com.liferay.login.web -H 1.0.0 my-fragment-project
 
-The command above creates an activator project named `my-fragment-project` in
+The command above creates a fragment project named `my-fragment-project` in
 the current directory. You specified the host bundle name as
 `com.liferay.login.web` and and the host bundle's version to `1.0.0`. The folder
 structure is created, but there are no files. The only files created are the


### PR DESCRIPTION
Fixed a typo probably introduced when the activator section was used as a baseline for the fragment section.