### PR TITLE
Blade create doesn't create *-web folder

### DIFF
--- a/develop/tutorials/articles/100-tooling/01-blade-cli/02-creating-modules-with-blade-cli/05-service-builder-template.markdown
+++ b/develop/tutorials/articles/100-tooling/01-blade-cli/02-creating-modules-with-blade-cli/05-service-builder-template.markdown
@@ -22,23 +22,9 @@ this:
         - `bnd.bnd`
         - `build.gradle`
         - `service.xml`
-    - `tasks-web`
-        - `src`
-            - `main`
-                - `java`
-                    - `com/liferay/docs/tasks/portlet`
-                        - `TasksPortlet.java`
-                - `resources`
-                    - `content`
-                        - `Language.properties`
-                    - `META-INF`
-                        - `resources`
-                            - `init.jsp`
-                            - `view.jsp`
-        - `bnd.bnd`
-        - `build.gradle`
     - `build.gradle`
-    - `settings.gradle`
+    - `gradlew`
+    - `gradlew.bat`
 
 To generate your service and API classes for the `*-api` and `*-service`
 modules, replace the `service.xml` file in the `*-service` module. Then run


### PR DESCRIPTION
I just confirmed with Greg Amerson and Andy Wu that "blade create" for Service Builder portlet doesn't create *-web folder along with *-api and *-service folder for now. 

Even though they also mentioned that this behavior was still subject to change (and they didn't propose the specific time frame), the document should reflect the current behavior.