### PR TITLE
reflect repository change in script location

### DIFF
--- a/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
+++ b/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
@@ -8,7 +8,7 @@ scripts takes it to the next level.
 Examine the default single approver workflow definition file included with Kaleo
 for an overview of how the feature works. You can find the default single
 approver workflow definition file in Liferay's source code here:
-[https://github.com/liferay/liferay-portal/blob/7.0.x/modules/portal/portal-workflow-kaleo-service/src/META-INF/definitions/single-approver-definition.xml](https://github.com/liferay/liferay-portal/blob/7.0.x/modules/portal/portal-workflow-kaleo-service/src/META-INF/definitions/single-approver-definition.xml).
+[hhttps://github.com/liferay/com-liferay-portal-workflow/tree/7.0.x/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml](https://github.com/liferay/com-liferay-portal-workflow/tree/7.0.x/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml).
 The final step in the workflow runs a script that makes content available for
 use. As you can see in the snippet below, it uses JavaScript to access the Java
 class associated with the workflow to set the status of the content to


### PR DESCRIPTION
When the repositories were split, the URL for single-approver.xml changed