### PR TITLE
Update ES installation steps - install plugins used by Liferay

### DIFF
--- a/discover/deployment/articles/01-installing-liferay/10-configuring-search.markdown
+++ b/discover/deployment/articles/01-installing-liferay/10-configuring-search.markdown
@@ -93,7 +93,14 @@ whatever you want to name your cluster:
 
 Of course, this isn't a very imaginative name; you may choose to name your
 cluster `finders_keepers` or something else you can remember more easily. Save
-the file. 
+the file. If you don't set the cluster name in your Elasticsearch installation, 
+it will default to *elasticsearch*.
+
+Liferay uses several features of Elasticsearch, which are not part of the default 
+installation. You will need to install these features as Elasticsearch plugins:
+
+    [Elasticsearch Home]/bin/plugin install analysis-smartcn
+    [Elasticsearch Home]/bin/plugin install analysis-kuromoji
 
 Now you can start Elasticsearch. Run the executable for your operating system
 from the `[Elasticsearch Home]/bin` folder: 


### PR DESCRIPTION
Based on https://issues.liferay.com/browse/LPS-65120, you need to install several plugins into your remote ES manually. Otherwise indexing from Liferay into ES will log many exceptions, ES will not be able to find some mappers which Liferay schema for ES index is using. Seems like analyzers for some complex languages like Chinese and Japanese are being used by Liferay. 

Please note there may be other plugins needed as well, depending how Liferay uses ES. These two are just the ones which I spotted in the logs.
