### PR TITLE
Spell out Declarative Services (DS)

### DIFF
--- a/develop/tutorials/articles/100-tooling/03-blade-cli/03-creating-modules-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/03-creating-modules-with-blade-cli.markdown
@@ -28,7 +28,7 @@ are displayed. A list of the `create` options are listed below:
   created, provide the name of the host bundle version.
 - `-p, --packagename <string>`: The package name to use when creating the
   project.
-- `-s, --service <string>`: If a new DS component needs to be created, provide
+- `-s, --service <string>`: If a new Declarative Services (DS) component needs to be created, provide
   the name of the service to be implemented. Note that in this context, the term
   *service* refers to an OSGi service, not to a Liferay API.
 - `-t, --template <template>`: The project template to use when creating the


### PR DESCRIPTION
However, a proper hyperlink for "Declarative Services" should be helpful.
