### PR TITLE
Fix the name of the Ruby Sass property

### DIFF
--- a/develop/tutorials/articles/260-themes-and-layout-templates/02-themes-generator.markdown
+++ b/develop/tutorials/articles/260-themes-and-layout-templates/02-themes-generator.markdown
@@ -170,7 +170,7 @@ using the Ruby version of Sass, you must configure the theme to support Compass.
 To do so, follow these steps:
 
 1.  Open the `package.json` file found in the root folder of your theme, and
-    locate the `supportCompass` property and change it from `false` to `true`.
+    locate the `rubySass` property and change it from `false` to `true`.
 
     Now that your theme is set to support Compass, you must install the Ruby
     Sass middleware and save it as a dependency for your theme.


### PR DESCRIPTION
The documentation states that the `supportCompass` property must be changed to true, but the name of the property in a generated package.json file is actually `rubySass`.