### PR TITLE
Package name correction and warning

### DIFF
--- a/discover/portal/articles/03-collaboration/01-managing-documents-and-media/03-repository-types.markdown
+++ b/discover/portal/articles/03-collaboration/01-managing-documents-and-media/03-repository-types.markdown
@@ -48,10 +48,12 @@ For example, you can store documents and media files in your Liferay instance's
 database using DBStore. To enable DBStore, add the following [`dl.store.impl`](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Document%20Library%20Service)
 portal property to a `portal-ext.properties` file in your [Liferay Home](/discover/deployment/-/knowledge_base/7-0/installing-liferay-portal#liferay-home):
 
-    dl.store.impl=com.liferay.portlet.documentlibrary.store.DBStore
+    dl.store.impl=com.liferay.portal.store.db.DBStore
 
 Remember to restart your @product@ server after updating your
 `portal-ext.properties` file in order for your customizations to take effect.
+
+**If you are upgrading from 6.2** note that the package names of the stores have changed from `com.liferay.portlet.documentlibrary.store` to `com.liferay.portal.store.*` - failing to change the store's implementation package will naturally result in a not working installation.
 
 There are properties related to document library stores that have been moved
 from `portal-ext.properties` to OSGI configuration files. The following mapping


### PR DESCRIPTION
The packages of Store implementations have changed from 6.2 to 7.0 - this is easy to miss when bringing the properties forward and the error messages one is running in aren't really helpful. With an explicit warning here, hopefully less people will run into this problem. Plus, the documentation contained an old package name, which doesn't help as well...

@codyhoag @jhinkey 