### PR TITLE
Include <template-handler> for event-listing portlet

### DIFF
--- a/develop/tutorials/code/tutorials-sdk/portlets/event-listing-portlet/docroot/WEB-INF/liferay-portlet.xml
+++ b/develop/tutorials/code/tutorials-sdk/portlets/event-listing-portlet/docroot/WEB-INF/liferay-portlet.xml
@@ -5,6 +5,7 @@
 	
 	<portlet>
 		<portlet-name>event-listing</portlet-name>
+		<template-handler>com.liferay.docs.eventlisting.template.LocationListingPortletDisplayTemplateHandler</template-handler>
 		<icon>/icon.png</icon>
 		<header-portlet-css>/css/main.css</header-portlet-css>
 		<footer-portlet-javascript>


### PR DESCRIPTION
<template-handler> tag was missed out. Unable to get ADT dropdown option in configuration window in Liferay 6.2 EE.