### PR TITLE
$themeDisplay.layouts not working

### DIFF
--- a/develop/tutorials/articles/110-portlets/02-liferay-soy-portlet/01-creating-a-soy-portlet.markdown
+++ b/develop/tutorials/articles/110-portlets/02-liferay-soy-portlet/01-creating-a-soy-portlet.markdown
@@ -352,12 +352,14 @@ which demonstrates the features covered in this section:
                             navigate-to{/msg}
                             </div>
 
+/*
                             {foreach $layout in $themeDisplay.layouts}
                                     <a class="list-group-item"
                                     href="{$layout.friendlyURL}">
                                     {$layout.nameCurrentValue}
                                     </a>
                             {/foreach}
+*/
                     </div>
 
                     <h3>{msg desc=""}navigating-between-views{/msg}</h3>


### PR DESCRIPTION
When I try to use the sample code for the View soy template, $themeDisplay.layouts is not working and throwing an exception:
Caused by: com.google.template.soy.tofu.SoyTofuException: In 'foreach' command {foreach $layout in $themeDisplay.layouts}<a class="list-group-item" href="{$layout.friendlyURL |filterNormalizeUri |escapeHtmlAttribute}">{$layout.nameCurrentValue |escapeHtml}</a>{/foreach}, the data reference does not resolve to a SoyList (encountered type com.google.template.soy.data.restricted.UndefinedData).

I'm using 7.0.2 GA3 and IDE 3.1.0 M1 (stable milestone release).