### PR TITLE
Broken links between pages about scripting

### DIFF
--- a/discover/portal/articles/07-setting-up-liferay/04-scripting/01-invoking-liferay-services-from-scripts.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/04-scripting/01-invoking-liferay-services-from-scripts.markdown
@@ -140,8 +140,8 @@ engine.
 
 ## Related Topics [](id=related-topics)
 
-[Running Scripts From the Script Console](/discover/deployment/-/knowledge_base/7-0/running-scripts-from-the-script-console)
+[Running Scripts From the Script Console](/discover/portal/-/knowledge_base/7-0/running-scripts-from-the-script-console)
 
-[Leveraging the Script Engine in Workflow](/discover/deployment/-/knowledge_base/7-0/leveraging-the-script-engine-in-workflow)
+[Leveraging the Script Engine in Workflow](/discover/portal/-/knowledge_base/7-0/leveraging-the-script-engine-in-workflow)
 
-[Using Custom Java Tools in the Script Engine](/discover/deployment/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)
+[Using Custom Java Tools in the Script Engine](/discover/portal/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)

--- a/discover/portal/articles/07-setting-up-liferay/04-scripting/02-running-scripts-from-script-console.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/04-scripting/02-running-scripts-from-script-console.markdown
@@ -262,8 +262,8 @@ you'll learn how to leverage Liferay's script engine for designing workflows.
 
 ## Related Topics [](id=related-topics)
 
-[Invoking Liferay Services From Scripts](/discover/deployment/-/knowledge_base/7-0/invoking-liferay-services-from-scripts)
+[Invoking Liferay Services From Scripts](/discover/portal/-/knowledge_base/7-0/invoking-liferay-services-from-scripts)
 
-[Leveraging the Script Engine in Workflow](/discover/deployment/-/knowledge_base/7-0/leveraging-the-script-engine-in-workflow)
+[Leveraging the Script Engine in Workflow](/discover/portal/-/knowledge_base/7-0/leveraging-the-script-engine-in-workflow)
 
-[Using Custom Java Tools in the Script Engine](/discover/deployment/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)
+[Using Custom Java Tools in the Script Engine](/discover/portal/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)

--- a/discover/portal/articles/07-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
@@ -117,8 +117,8 @@ workflow, see Liferay's
 
 ## Related Topics [](id=related-topics)
 
-[Invoking Liferay Services From Scripts](/discover/deployment/-/knowledge_base/7-0/invoking-liferay-services-from-scripts)
+[Invoking Liferay Services From Scripts](/discover/portal/-/knowledge_base/7-0/invoking-liferay-services-from-scripts)
 
-[Running Scripts From the Script Console](/discover/deployment/-/knowledge_base/7-0/running-scripts-from-the-script-console)
+[Running Scripts From the Script Console](/discover/portal/-/knowledge_base/7-0/running-scripts-from-the-script-console)
 
-[Using Custom Java Tools in the Script Engine](/discover/deployment/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)
+[Using Custom Java Tools in the Script Engine](/discover/portal/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine)


### PR DESCRIPTION
I suspect the pages have moved from 'deployment' to 'portal' but the links between them were not updated. Fixed this.