### PR TITLE
LRDOCS-3488 Fix legacy PDF links

### DIFF
--- a/develop/tutorials/articles/00-intro/tutorials-earlier-intro.markdown
+++ b/develop/tutorials/articles/00-intro/tutorials-earlier-intro.markdown
@@ -7,7 +7,7 @@ This page provides access to developer documentation for Liferay Portal version
 
 ### Liferay Portal 6.0 [](id=liferay-portal-6-0)
 
-<a href="/documents/10184/359671/liferay-developer-guide-6.0.pdf" target="_blank">
+<a href="/documents/10184/307163/liferay-developer-guide-6.0.pdf/ce0604fa-1fc2-412e-a72a-3b049b732222" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 6.0 Developer's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
@@ -16,7 +16,7 @@ This page provides access to developer documentation for Liferay Portal version
 
 ### Liferay Portal 5.2 [](id=liferay-portal-5-2)
 
-<a href="/documents/10184/359671/liferay-developer-guide-5.2.pdf" target="_blank">
+<a href="/documents/10184/307163/liferay-developer-guide-5.2.pdf/9bfcd6c0-09e8-4a26-bfd5-7a58090838fb" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 5.2 Developer's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
@@ -25,7 +25,7 @@ This page provides access to developer documentation for Liferay Portal version
 
 ### Liferay Portal 5.1 [](id=liferay-portal-5-1)
 
-<a href="/documents/10184/359671/liferay-developer-guide-5.1.pdf" target="_blank">
+<a href="/documents/10184/307163/liferay-developer-guide-5.1.pdf/906c017e-dfa5-4b0d-ad48-0e5217658e95" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 5.1 Developer's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>

--- a/discover/portal/articles/00-intro/portal-earlier-intro.markdown
+++ b/discover/portal/articles/00-intro/portal-earlier-intro.markdown
@@ -7,7 +7,7 @@ Portal version 6.0 and earlier.
 
 ### Liferay Portal 6.0 [](id=liferay-portal-6-0)
 
-<a href="/documents/10184/359510/liferay-administrator-guide-6.0.pdf" target="_blank">
+<a href="/documents/10184/307080/liferay-administrator-guide-6.0.pdf/340b0adc-5575-49f6-8acf-a9d24ece68d9" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 6.0 Administrator's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
@@ -16,7 +16,7 @@ Portal version 6.0 and earlier.
 
 ### Liferay Portal 5.2 [](id=liferay-portal-5-2)
 
-<a href="/documents/10184/359510/liferay-administrator-guide-5.2.pdf" target="_blank">
+<a href="/documents/10184/307080/liferay-administrator-guide-5.2.pdf/aec4dcfe-07b0-4d96-b603-71b2fe98dd34" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 5.2 Administrator's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
@@ -25,12 +25,12 @@ Portal version 6.0 and earlier.
 
 ### Liferay Portal 5.1 [](id=liferay-portal-5-1)
 
-<a href="/documents/10184/359510/liferay-administrator-guide-5.1.pdf" target="_blank">
+<a href="/documents/10184/307080/liferay-administrator-guide-5.1.pdf/9157da13-6b85-4fc0-af7d-969137da9935" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 5.1 Administrator's Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
 
-<a href="/documents/10184/359510/liferay-quick-start-guide-5.1.pdf" target="_blank">
+<a href="/documents/10184/307080/liferay-quick-start-guide-5.1.pdf/fc811878-e333-4ec7-ba22-b0808d8f3b99" target="_blank">
 ![PDF](../../images/pdfunlock32x32.png) Liferay Portal 5.1 Quick Start Guide
 <span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>


### PR DESCRIPTION
@sez11a I was unable to find the `6.0.x` branch on your remote Github repo, so I'm sending this PR to the `liferay` account for merging. The current links for our legacy PDF docs are pointing to dev-uat, which is not accessible by most readers. The links residing in our Markdown are also invalid, due to the LDN crash. I've updated them. Thanks!