### PR TITLE
Fixes typo in API explanation

### DIFF
--- a/develop/tutorials/articles/11-apis/00-intro.markdown
+++ b/develop/tutorials/articles/11-apis/00-intro.markdown
@@ -1,6 +1,6 @@
 # Liferay APIs [](id=liferay-apis)
 
-An *Application Programing Interface* (API) is a protocol that, when invoked,
+An *Application Programming Interface* (API) is a protocol that, when invoked,
 performs an action or set of actions. You can invoke an API from your own code
 directly through a Java invocation, or through web services. This chapter
 provides an overview of several essential Liferay APIs available to you for use


### PR DESCRIPTION
Just a simple typo of missing a single 'm' that should be fixed.