### PR TITLE
Update 05-installing-liferay-on-wildfly.markdown

### DIFF
--- a/discover/deployment/articles/01-installing-liferay/05-installing-liferay-on-wildfly.markdown
+++ b/discover/deployment/articles/01-installing-liferay/05-installing-liferay-on-wildfly.markdown
@@ -43,6 +43,7 @@ third-parties, as described below.
 
     - `com.liferay.osgi.service.tracker.collections.jar` - [http://mvnrepository.com/artifact/com.liferay/com.liferay.osgi.service.tracker.collections](http://mvnrepository.com/artifact/com.liferay/com.liferay.osgi.service.tracker.collections)
     - `com.liferay.registry.api.jar` - [https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.registry.api](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.registry.api)
+    (Note: To avoid problems, remove number version from JAR file name).
 
 4. Create the file `module.xml` in the
    `$WILDFLY_HOME/modules/com/liferay/portal/main` folder and insert the

--- a/discover/deployment/articles/01-installing-liferay/05-installing-liferay-on-wildfly.markdown
+++ b/discover/deployment/articles/01-installing-liferay/05-installing-liferay-on-wildfly.markdown
@@ -339,7 +339,7 @@ If you want to use the built-in @product@ mail session, you can skip this sectio
 Specify your mail subsystem in `standalone.xml` as in the following example:
 
     <subsystem xmlns="urn:jboss:domain:mail:2.0">
-        <mail-session jndi-name="java:jboss/mail/MailSession" >
+        <mail-session jndi-name="java:jboss/mail/MailSession" name="mail-smtp">
             <smtp-server ssl="true" outbound-socket-binding-ref="mail-smtp" username="USERNAME" password="PASSWORD"/>
        </mail-session>
     </subsystem>


### PR DESCRIPTION
Two changes:
  - We had problems when start server with JAR File "com.liferay.registry.api-1.1.0.jar" downloaded, but we rename to "com.liferay.registry.api.jar" and it works well.
  - Add name attribute to avoid error during startup server.