### PR TITLE
Replace duplicate HTTP example with AJP example

### DIFF
--- a/discover/deployment/articles/02-installing-liferay/04-installing-liferay-on-tomcat.markdown
+++ b/discover/deployment/articles/02-installing-liferay/04-installing-liferay-on-tomcat.markdown
@@ -211,15 +211,11 @@ Next, you need to configure Tomcat for running @product@.
 
     And
 
-        <Connector port="8080" protocol="HTTP/1.1"
-                   connectionTimeout="20000"
-                   redirectPort="8443" />
+        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
 
     should become
 
-        <Connector port="8080" protocol="HTTP/1.1"
-                   connectionTimeout="20000"
-                   redirectPort="8443" URIEncoding="UTF-8" />
+        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" URIEncoding="UTF-8" />
 
 6. If you're on Unix, Linux, or Mac OS, navigate to your `$TOMCAT_HOME/bin`
    folder and run the following command


### PR DESCRIPTION
line 204 references an HTTP and AJP change, yet the examples both reference a duplicate example of just the HTTP property. I added the AJP property.