### PR TITLE
LRDOCS-3614 Expanded the "app-server.properties" and descriptions

### DIFF
--- a/discover/deployment/articles/06-upgrading-liferay/00-upgrading-liferay-intro.markdown
+++ b/discover/deployment/articles/06-upgrading-liferay/00-upgrading-liferay-intro.markdown
@@ -286,13 +286,18 @@ configuration that you can customize for your use:
 
 -`app-server.properties`:
 
-    dir=/home/user/servers/liferay7/tomcat-8.0.32
-    portal.dir=webapps/ROOT
-    global.dir.lib=lib
+	dir=../../tomcat-8.0.32
+	global.lib.dir=/lib
+	portal.dir=/webapps/ROOT
+	server.detector.server.id=tomcat
+	extra.lib.dirs=/bin
 
-The `dir` setting is the folder where your app server is installed. The
-`portal.dir` setting is the folder where @product@ is installed in your app
-server. The `global.dir.lib` is the app server's library folder. 
+The `dir` setting is the folder where your app server is installed. The 
+`global.dir.lib` is the app server's library folder. The `portal.dir` 
+setting is the folder where @product@ is installed in your app
+server. The `server.detector.server.id` is informing the tool
+of which application server is being used. The `extra.lib.dirs` 
+is the app server's binary folder.
 
 -`portal-upgrade-datasource.properties`:
 


### PR DESCRIPTION
Expanded the "app-server.properties" configuration example to better reflect what the file looks like after manual input. I also expanded the description to inform the user what each line is looking for.

This will allow the upgrade tool to run without asking the user to input the data due to missing information. Additionally, to my current understanding, those lines are usable as is in any DXP upgrade as long as the user's tomcat is tomcat-8.0.32.