### PR TITLE
Change Configurable to ConfigurableUtil

### DIFF
--- a/develop/tutorials/articles/180-configuration/02-implementing-configuration-actions.markdown
+++ b/develop/tutorials/articles/180-configuration/02-implementing-configuration-actions.markdown
@@ -97,9 +97,8 @@ portlet class:
     import org.osgi.service.component.annotations.Modified;
 
     import com.liferay.docs.exampleconfig.configuration.ExampleConfiguration;
+    import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
     import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-
-    import aQute.bnd.annotation.metatype.Configurable;
 
     @Component(
         configurationPid =
@@ -135,7 +134,7 @@ portlet class:
             @Activate
             @Modified
             protected void activate(Map<Object, Object> properties) {
-                    _exampleConfiguration = Configurable.createConfigurable(
+                    _exampleConfiguration = ConfigurableUtil.createConfigurable(
                             ExampleConfiguration.class, properties);
             }
 
@@ -198,11 +197,10 @@ example:
     import org.osgi.service.component.annotations.Modified;
 
     import com.liferay.docs.exampleconfig.configuration.ExampleConfiguration;
+    import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
     import com.liferay.portal.kernel.portlet.ConfigurationAction;
     import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
     import com.liferay.portal.kernel.util.ParamUtil;
-
-    import aQute.bnd.annotation.metatype.Configurable;
 
     @Component(
         configurationPid = "com.liferay.docs.exampleconfig.configuration.ExampleConfiguration",
@@ -242,7 +240,7 @@ example:
         @Activate
         @Modified
         protected void activate(Map<Object, Object> properties) {
-            _exampleConfiguration = Configurable.createConfigurable(
+            _exampleConfiguration = ConfigurableUtil.createConfigurable(
                 ExampleConfiguration.class, properties);
         }
 


### PR DESCRIPTION
It seems that Configurable class will not load the designated configuration class as expected. Changing to ConfigurableUtil as used in this Blade sample solved this issue:
https://github.com/liferay/liferay-blade-samples/blob/master/liferay-workspace/modules/blade.configurationaction/src/main/java/com/liferay/blade/samples/configurationaction/BladeMessagePortlet.java#L75