### PR TITLE
Removed superfluous 'it' and confusing parenthesis

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/01-whats-changed-and-what-hasnt/00-whats-changed-and-what-hasnt-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/01-whats-changed-and-what-hasnt/00-whats-changed-and-what-hasnt-intro.markdown
@@ -56,8 +56,7 @@ them.
 
 5. Registration of classes implementing extension points is now simpler
 and more consistent; it's based on the standard `@Component` annotation instead
-of declarations it in `portal.properties` (in some cases) or `portlet.xml` (in
-some others). Note, previous registration mechanisms have been preserved where
+of declaration's in `portal.properties` or `portlet.xml`. Note, previous registration mechanisms have been preserved where
 possible.
 
 6. Third party extensions and applications are now first-class citizens.


### PR DESCRIPTION
The 'it' placed after declarations on line 59 is an obvious typo. I also removed two parenthetical notes "(in some cases" and "(in some others)". I don't believe these parenthetical notes add any context or clarification to the statement. I assume the author was trying to distinguish between or and xor (opting for xor) which might be wrong anyway. If I remember correctly there were instances in 6.2 where the same configuration can be made in portlet.xml as in portal.properties (disabling csrf token for example). Either way if it is decided that xor is the correct logical structure, and that using the colloquial or isn't satisfactory, I still think there would be a clearer way to distinguish it.