### PR TITLE
add missing details about factory settings

### DIFF
--- a/discover/portal/articles/07-setting-up-liferay/01-system-settings/01-system-settings.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/01-system-settings/01-system-settings.markdown
@@ -131,8 +131,13 @@ the System Settings options button
 Settings*. The `.config` files for all the entries you edited then download in a 
 ZIP file. 
 
+Before importing into a new system you will need to edit eventual factory based 
+configurations because they will be exported as `<factoryPid>-<UUID>.config` which is
+not importable. The id after the dash needs to not contain any additional dashes
+so for example the above exported string would become `<factoryPid>-<any_alfanumeric_string>.config`.
+
 To make these configurations active in the destination @product@ system, simply 
-unzip and place the `.config` files in the `[Liferay_Home]/osgi/modules` folder. 
+unzip and place the `.config` files in the `[Liferay_Home]/osgi/configs` folder.
 
 Awesome! Now you know what System Settings is and how to use it. All that's left 
 is to explore the entries to see what configuration options you can make. If you 


### PR DESCRIPTION
The factory based configurations (instances of the factory) are exported by appending an UUID to the PID and if trying to import that instances it will fail because of parsing issues. The factory instance configurations need to have this format <PID>-<ANY_STRING>.config