### PR TITLE
Update 04-overriding-service-references.markdown

### DIFF
--- a/develop/tutorials/articles/300-osgi-basics/04-overriding-service-references.markdown
+++ b/develop/tutorials/articles/300-osgi-basics/04-overriding-service-references.markdown
@@ -204,7 +204,7 @@ service references on the fly.
 1.  Create a configuration file named after the referencing component. Here's 
     the example component's configuration file name: 
 
-        override.my.service.reference.OverrideMyServiceReference.config
+        override.my.service.reference.portlet.OverrideMyServiceReferencePortlet.config
  
     +$$$
 


### PR DESCRIPTION
The name of de file config should be override.my.service.reference.portlet.OverrideMyServiceReferencePortlet.config 
instead of override.my.service.reference.OverrideMyServiceReference.config