### PR TITLE
Fixes "id" of MyAppConfiguration

### DIFF
--- a/develop/tutorials/articles/180-configuration/01-making-apps-configurable.markdown
+++ b/develop/tutorials/articles/180-configuration/01-making-apps-configurable.markdown
@@ -75,7 +75,7 @@ First create a Java interface to represent the configuration and its default
 values. Using a Java interface allows for an advanced type system for each
 configuration option. Here is an example of such an interface:
 
-    @Meta.OCD(id = "com.foo.bar.MyAppConfiguration")
+    @Meta.OCD(id = "com.liferay.docs.exampleconfig.ExampleConfiguration")
     public interface MyAppConfiguration {
 
         @Meta.AD(


### PR DESCRIPTION
ID used in the rest of the document is "com.liferay.docs.exampleconfig.ExampleConfiguration" instead of "com.foo.bar.MyAppConfiguration".