### PR TITLE
Removes apostrophe from a plural

### DIFF
--- a/develop/tutorials/articles/244-liferay-js-api/00-liferay-js-api-intro.markdown
+++ b/develop/tutorials/articles/244-liferay-js-api/00-liferay-js-api-intro.markdown
@@ -1,4 +1,4 @@
-# Liferay JavaScript API's [](id=liferay-javascript-apis)
+# Liferay JavaScript APIs [](id=liferay-javascript-apis)
 
 The `Liferay` JavaScript object is populated with some helpful tools. This
 section contains a comprehensive list of some of the most useful utilities you


### PR DESCRIPTION
Since it's neither a possessive or a contraction, no apostrophe should be necessary.  Or do we use an apostrophe here simply as a separator?