### PR TITLE
The profile documentation is incomplete

### DIFF
--- a/discover/deployment/articles/02-advanced-portal-operation/05-patching-liferay.markdown
+++ b/discover/deployment/articles/02-advanced-portal-operation/05-patching-liferay.markdown
@@ -279,6 +279,11 @@ is only valid if your `patching.mode` is `source`.
 You can have as many profiles as you want, and use the same Patching Tool to
 patch all of them. This helps to keep all your installations in sync. 
 
+To run the patching tool using a created profile include the profile name within
+the command being used. An example would be:
+
+`./patching-tool.sh [profile name] install`
+
 ## New features [](id=new-features)
 
 Starting with Version 18 of the Patching Tool, we have included some major


### PR DESCRIPTION
The profile usage documentation does not clearly identify that the profile name needs to be included within the patching-tool command. This can be logically determined however clear instructions would reduce concern and ensure a smoother customer experience.