### PR TITLE
Fixed inconsistency in docs

### DIFF
--- a/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
+++ b/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
@@ -119,7 +119,7 @@ Now you'll look at the classes and interfaces generated for the entities you
 specified. Each entity has similar classes generated for it, depending on what
 you specfied for them in the `service.xml`. You won't have to customize more
 than three classes for each entity. These customizable classes are
-`*LocalServiceImpl`, `*ServiceImpl`, and `*ModelImpl`.
+`*LocalServiceImpl`, `*ServiceImpl`, and `*Impl`.
 
 - Persistence
     - `[ENTITY_NAME]Persistence`: Persistence interface that defines CRUD


### PR DESCRIPTION
Original version states that *ModelImpl is editable, but that file has the normal "do not modify" warning. I believe it's meant to reference *Impl (though *Impl doesn't seem to be generated by default (at all?) with builder version 1.0.174)