### PR TITLE
Add new title for configuration details.

### DIFF
--- a/discover/deployment/articles/03-configuring-liferay/02-document-repository.markdown
+++ b/discover/deployment/articles/03-configuring-liferay/02-document-repository.markdown
@@ -284,15 +284,17 @@ that resides in your @product@ installation's class path  (e.g.,
 Consult the Amazon Simple Storage documentation for additional details on using
 Amazon's service.
 
+## Configuration Details [](id=configuration-details)
+
 There are properties related to document library stores that have been moved
 from `portal-ext.properties` to OSGi configuration files. The following mapping
 shows you how to configure those properties if needed:
 
 #### CMIS Store [](id=cmis)
 
-From `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.cmis.CMISStore`
+In `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.cmis.CMISStore`
 
-To `osgi/configs`: `com.liferay.portal.store.cmis.configuration.CMISStoreConfiguration.cfg`
+In `osgi/configs/com.liferay.portal.store.cmis.configuration.CMISStoreConfiguration.cfg`:
 
 Property | Default | Required
 ---------|---------|---------
@@ -303,9 +305,9 @@ Property | Default | Required
 
 #### File Store [](id=file-store)
 
-From `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore`
+In `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.file.system.FileSystemStore`
 
-To `osgi/configs`: `com.liferay.portal.store.file.system.configuration.FileSystemStoreConfiguration.cfg`
+In `osgi/configs/com.liferay.portal.store.file.system.configuration.FileSystemStoreConfiguration.cfg`:
 
 Property | Default | Required
 ---------|---------|---------
@@ -317,9 +319,9 @@ Property | Default | Required
 `portal-ext.properties` and `.config` files are required to configure the 
 advanced file system store.**
 
-From `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.file.system.AdvancedFileSystemStore`
+In `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.file.system.AdvancedFileSystemStore`
 
-To `osgi/configs`: `com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.cfg`
+In `osgi/configs/com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration.cfg`:
 
 Property | Default | Required
 ---------|---------|---------
@@ -327,9 +329,9 @@ Property | Default | Required
 
 #### JCR [](id=jcr)
 
-From `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.jcr.JCRStore`
+In `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.jcr.JCRStore`
 
-To `osgi/configs`: `com.liferay.portal.store.jcr.configuration.JCRStoreConfiguration.cfg`
+In `osgi/configs/com.liferay.portal.store.jcr.configuration.JCRStoreConfiguration.cfg`:
 
 Property | Default | Required
 ---------|---------|---------
@@ -346,9 +348,9 @@ Property | Default | Required
 
 #### S3 [](id=s3)
 
-From `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.s3.S3Store`
+In `portal-ext.properties`: `dl.store.impl=com.liferay.portal.store.s3.S3Store`
 
-To `osgi/configs`: `com.liferay.portal.store.s3.configuration.S3StoreConfiguration.cfg`
+In `osgi/configs/com.liferay.portal.store.s3.configuration.S3StoreConfiguration.cfg`:
 
 Property | Default | Required
 ---------|---------|---------


### PR DESCRIPTION
All configuration details should be in their own section title instead of seemingly under "Using Amazon Simple Storage Service". in each configuration detail, the "From" and "To" word in the beginning are confusing, because the detail never shows the old settings. Changing both to "In" makes more sense.