### PR TITLE
Remove element <execution-type> from timer actions

### DIFF
--- a/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
+++ b/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
@@ -501,7 +501,6 @@ were at their desk that hadn't reviewed content assigned to them.
 					]]>
 				</script>
 				<script-language></script-language>
-				<execution-type></execution-type>
 		</action>
     </timer-actions>
 


### PR DESCRIPTION
According to the XSD used to check the valid workflow definitions to portal 6.2 (https://www.liferay.com/dtd/liferay-workflow-definition_6_2_0.xsd), the element <execution-type> is not valid for the timer actions.