### PR TITLE
Use correct spelling of ECMAScript

### DIFF
--- a/develop/tutorials/articles/01-introduction-to-liferay-development/20-frontend-development-in-liferay/00-frontend-development-in-liferay-intro.markdown
+++ b/develop/tutorials/articles/01-introduction-to-liferay-development/20-frontend-development-in-liferay/00-frontend-development-in-liferay-intro.markdown
@@ -10,7 +10,7 @@ If you've used Liferay in the past, you can of course continue to use Liferay's
 venerable Alloy UI, but you are also free to use the front-end technologies you
 love the most:
 
--   EcmaScript 2015
+-   ECMAScript 2015
 -   Metal.js (developed by Liferay)
 -   AlloyUI (developed by Liferay)
 -   jQuery (included)


### PR DESCRIPTION
The language is officially stylised as [ECMAScript](https://en.wikipedia.org/wiki/ECMAScript) not _EcmaScript_.