### PR TITLE
Replace Angular 1 for Angular JS & Angular for Angular 2

### DIFF
--- a/develop/tutorials/articles/01-introduction-to-liferay-development/01-fundamentals.markdown
+++ b/develop/tutorials/articles/01-introduction-to-liferay-development/01-fundamentals.markdown
@@ -172,7 +172,7 @@ You can also use any JavaScript library, including
 -   [Metal.js](http://metaljs.com/) (developed by Liferay)
 -   [jQuery](https://jquery.com/) (included) 
 -   Lodash (included)
--   Angular 1 or 2
+-   Angular JS or Angular
 -   React
 -   Your library of choice
 


### PR DESCRIPTION
Referring to Angular 1 or 2 is a little bit outdated. Angular JS is the preferred way to refer to Angular 1, and simply 'Angular' is the term used to refer to Angular 2 and onwards (the current Angular version is v6).