### PR TITLE
Fixed wrong code example intro text

### DIFF
--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
@@ -82,7 +82,7 @@ To send messages asynchronously, consider using
 
 The [`SingleDestinationMessageSender` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SingleDestinationMessageSender.html)
 wraps the Message Bus to send messages asynchronously. This class demonstrates
-using a `SynchronousMessageSender`:
+using a `SingleDestinationMessageSender`:
 
     @Component(
         immediate = true,


### PR DESCRIPTION
The text for the asynchronous message sending example said that is uses SynchronousMessageSender what does not make sense and do not follow the example itself.