### PR TITLE
Fix broken links in Using JavaScript in Your Portlets

### DIFF
--- a/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/01-preparing-your-js-files-for-es2015.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/01-preparing-your-js-files-for-es2015.markdown
@@ -20,7 +20,7 @@ to see what's polyfilled.
 
 Once you've completed writing your module, you can expose it by creating a
 `package.json` file that specifies your bundle's name and version. Make sure to
-create this in your module's root folder. The [js-logger]( https://github.com/liferay/liferay-docs/tree/master/develop/tutorials/code/osgi/modules/js-logger)
+create this in your module's root folder. The [js-logger](https://github.com/liferay/liferay-docs/tree/7.0.x/develop/tutorials/code/osgi/modules/js-logger)
 module, for example, specifies the following values in its `package.json` file:
 
     {

--- a/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/02-using-es2015-modules-in-your-portlets.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/02-using-es2015-modules-in-your-portlets.markdown
@@ -6,7 +6,7 @@ tag's `require` attribute makes it easy.
 
 This tutorial covers how to access in your portlets the modules you've exposed.
 The example module `logger.es` was written inside the
-[Console Logger Portlet]( https://github.com/liferay/liferay-docs/tree/master/develop/tutorials/code/osgi/modules/console-logger-portlet).
+[Console Logger Portlet](https://github.com/liferay/liferay-docs/tree/7.0.x/develop/tutorials/code/osgi/modules/console-logger-portlet).
 Once the portlet is deployed, and added to a page, you'll notice a printout in
 the console.
 


### PR DESCRIPTION
The GitHub links to the example codes are pointing to the master branch instead of 7.0.x