### PR TITLE
Update tab name for JavaScript Loader settings

### DIFF
--- a/develop/tutorials/articles/190-javascript-module-loaders/03-using-external-libraries.markdown
+++ b/develop/tutorials/articles/190-javascript-module-loaders/03-using-external-libraries.markdown
@@ -45,7 +45,7 @@ Liferay AMD Loader to use your Library. Follow these steps:
 1.  Open the Control Panel, navigate to *Configuration* &rarr; 
     *System Settings*. 
 
-2.  Click *JavaScript Loader* under the *Foundation* tab. 
+2.  Click *JavaScript Loader* under the *Infrastructure* tab. 
 
 3.  Uncheck the `expose global` option.
 


### PR DESCRIPTION
In 7.1, **JavaScript Loader** is no longer under _Foundation_ tab, but _Infrastructure_ tab.

![javascript-loader-infra-tab](https://user-images.githubusercontent.com/3501902/43508551-87a4c154-9570-11e8-9803-bca3ad0c21d9.png)
