### PR TITLE
Add missing comma in sitemap.json

### DIFF
--- a/develop/tutorials/articles/260-themes-and-layout-templates/01-themes/03-importing-resources-with-a-theme.markdown
+++ b/develop/tutorials/articles/260-themes-and-layout-templates/01-themes/03-importing-resources-with-a-theme.markdown
@@ -370,7 +370,7 @@ understand. Let's examine a sample `sitemap.json` file:
                 "friendlyURL": "/link-page",
                 "name": "Link to another Page",
                 "title": "Link to another Page",
-                "type": "link_to_layout"
+                "type": "link_to_layout",
                 "typeSettings": "linkToLayoutId=1"
             },
             {


### PR DESCRIPTION
`sitemap.json` is malformed in both 7.0 and 7.1 doc.