### PR TITLE
Update 03-adding-new-behavior-to-an-editor.markdown

### DIFF
--- a/develop/tutorials/articles/320-wysiwyg-editors/03-adding-new-behavior-to-an-editor.markdown
+++ b/develop/tutorials/articles/320-wysiwyg-editors/03-adding-new-behavior-to-an-editor.markdown
@@ -99,7 +99,7 @@ JSP files: it's the gateway for injecting JavaScript into your editor instance:
     this:
 
         dynamicIncludeRegistry.register(
-            "com.liferay.frontend.editors.web#ckeditor#onEditorCreate");
+            "com.liferay.frontend.editor.ckeditor.web#ckeditor#onEditorCreate");
 
     This registers the CKEditor into the Dynamic Include registry and specifies
     that JS code will be injected into the editor once it's created.
@@ -112,7 +112,7 @@ JSP files: it's the gateway for injecting JavaScript into your editor instance:
     the Creole implementation of the CKEditor, you could use the following
     key:
 
-        "com.liferay.frontend.editors.web#ckeditor_creole#onEditorCreate"
+        "com.liferay.frontend.editor.ckeditor.web#ckeditor_creole#onEditorCreate"
 
 That's it! The JS code that you created is now injected into the editor instance
 you've specified. You're now able to use JavaScript to add new behavior to your


### PR DESCRIPTION
Correct the registration key. If the key is not correct, the include(...) method will not be executed.