### PR TITLE
Adjust formatting

### DIFF
--- a/develop/tutorials/articles/270-forms/01-form-field-types/01-creating-form-field-types.markdown
+++ b/develop/tutorials/articles/270-forms/01-form-field-types/01-creating-form-field-types.markdown
@@ -19,7 +19,8 @@ There are several steps involved in creating a form field type:
 [Blade CLI](/develop/tutorials/-/knowledge_base/7-1/blade-cli) 
 or 
 [Liferay Dev Studio](/develop/tutorials/-/knowledge_base/7-1/creating-modules-with-liferay-ide). 
-There's a Blade template for creating form fields. Using the CLI, enter
+There's a Blade template for creating form fields. Using the CLI, enter:
+
 
     blade create -t form-field -v 7.1 -p com.liferay.docs.formfieldtype -c Time DDMTypeTime
 
@@ -62,7 +63,7 @@ upon module activation.
 Next craft the OSGi Component that marks your class as an implementation of
 `DDMFormFieldType`. 
 
-## Creating a `DDMFormFieldType` Component [](id=creating-a-ddmformfieldtype-component)
+## Creating a DDMFormFieldType Component [](id=creating-a-ddmformfieldtype-component)
 
 If you're creating a *Time* field type, define the Component at the top of your
 `*DDMFormFieldType` class like this:
@@ -117,7 +118,7 @@ the field's capabilities (for example, rendering and validation).
 
 Next code the `*DDMFormFieldType` class.
 
-## Implementing `DDMFormFieldType` [](id=implementing-ddmformfieldtype)
+## Implementing DDMFormFieldType [](id=implementing-ddmformfieldtype)
 
 Implementing the field type in Java is made easier because of
 `BaseDDMFormFieldType`, an abstract class you can leverage in your code.


### PR DESCRIPTION
The first change adds a new line so the code box doesn't overlap with the book image.

![image](https://user-images.githubusercontent.com/20053436/49120391-36351c80-f261-11e8-814f-09ab9aa33696.png)

The second change relates to formatting the title sections, similar to https://github.com/liferay/liferay-docs/pull/445
![image](https://user-images.githubusercontent.com/20053436/49120425-6bda0580-f261-11e8-8839-a9a1effc1853.png)
