### PR TITLE
Applications renamed to Widgets

### DIFF
--- a/develop/tutorials/articles/04-developing-a-web-application/02-creating-working-prototype/01-writing-your-first-liferay-application.markdown
+++ b/develop/tutorials/articles/04-developing-a-web-application/02-creating-working-prototype/01-writing-your-first-liferay-application.markdown
@@ -128,7 +128,7 @@ to be built and deployed.
     (![Add Widget](../../../images/icon-add-app.png)) in the upper right hand 
     corner.
 
-5.  Select *Applications*. In the Applications list, your application should
+5.  Select *Widgets*. In the Applications list, your application should
     appear in the Sample category. Its name is `Guestbook`. 
 
 ![Figure 5: This is the default Liferay home page. It contains the Hello World widget and the initial version of the Guestbook application that you created.](../../../images/default-portlet-application.png)


### PR DESCRIPTION
I've changed one occurrence of "Application" to "Widget", which referred to the actual label on the UI, left all the other "application" uses as they were. You might want to think about renaming more occurrences as you see fit. 
Got the idea for changing it from here: https://community.liferay.com/forums/-/message_boards/message/112109659