### PR TITLE
Update of the dependency version.

### DIFF
--- a/develop/tutorials/articles/150-web-services/05-service-builder-web-services/01-creating-remote-services.markdown
+++ b/develop/tutorials/articles/150-web-services/05-service-builder-web-services/01-creating-remote-services.markdown
@@ -230,9 +230,9 @@ failures is not satisfying the dependencies needed by the WSDD Builder for your
 project's code---there's no standard set. That said, the following dependencies
 are often required for portlet development: 
 
-    compileOnly group: "javax.portlet", name: "portlet-api", version: "2.0"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
-    compileOnly group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
+	compileOnly group: "com.liferay", name: "com.liferay.registry.api", version: "2.0.0"
 
 [Click here](/develop/tutorials/-/knowledge_base/7-1/configuring-dependencies) 
 for more information on finding and configuring dependencies for your apps. 


### PR DESCRIPTION
Without the correct dependencies, the following error is obtained:

```
Java2WSDL it.smc.despar.addressbook.service.http.ContactServiceSoap
- The class com.liferay.portal.kernel.portlet.LiferayPortletRequest does not contain a default constructor, which is a requirement for a bean class.  The class cannot be converted into an xml schema type.  An xml schema anyType will be used to define this class in the wsdl file.
 java.lang.NoClassDefFoundError: javax/portlet/MimeResponse$Copy
     at java.lang.Class.getDeclaredMethods0(Native Method)
     at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
     at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
     at java.lang.Class.getMethod0(Class.java:3018)
     at java.lang.Class.getMethod(Class.java:1784)
```