### PR TITLE
Update 01-theme-display.markdown

### DIFF
--- a/develop/tutorials/articles/244-liferay-js-api/01-theme-display.markdown
+++ b/develop/tutorials/articles/244-liferay-js-api/01-theme-display.markdown
@@ -120,7 +120,7 @@ directory |
 | getPlid | string | |
 | getPortalURL | string | |
 | getScopeGroupId | number | Returns the [group ID](/participate/liferaypedia/-/wiki/Main/Group+ID) of the current site |
-| getScopeGroupIdOrLiveGroupId | number | |
+| getSiteGroupIdOrLiveGroupId | number | Returns the [group ID](/participate/liferaypedia/-/wiki/Main/Group+ID) of the live site. Relevant for staging. |
 | getSessionId | number | |
 | getSiteGroupId | number | |
 | getURLControlPanel | string | |


### PR DESCRIPTION
Method name was changed, docu is wrong: Rename getScopeGroupIdOrLiveGroupId ->  getSiteGroupIdOrLiveGroupId
https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/theme/ThemeDisplay.html