### PR TITLE
Update 05-managing-the-target-platform-for-liferay-workspace.markdown

### DIFF
--- a/develop/tutorials/articles/100-tooling/04-liferay-workspace/05-managing-the-target-platform-for-liferay-workspace.markdown
+++ b/develop/tutorials/articles/100-tooling/04-liferay-workspace/05-managing-the-target-platform-for-liferay-workspace.markdown
@@ -130,11 +130,11 @@ To do this, your `build.gradle` file should look similar to this:
 
     buildscript {
         dependencies {
-            classpath group: "com.liferay", name: "com.liferay.gradle.plugins.target.platform", version "1.1.6"
+            classpath group: "com.liferay", name: "com.liferay.gradle.plugins.target.platform", version: "1.1.6"
         }
         repositories {
             maven {
-                url "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+                url "https://repository-cdn.liferay.com/nexus/content/groups/public"
             }
         }
     }


### PR DESCRIPTION
- Typo in dependency: missing colon between version: 1.1.6
- changed url to new cdn