### PR TITLE
Remove monospace font for titles

### DIFF
--- a/develop/tutorials/articles/240-product-navigation/01-customizing-the-product-menu/01-adding-custom-panel-categories.markdown
+++ b/develop/tutorials/articles/240-product-navigation/01-customizing-the-product-menu/01-adding-custom-panel-categories.markdown
@@ -39,7 +39,7 @@ define information about your entry. This takes only two steps:
 
 Both of these steps are described below. 
 
-### Insert the `@Component` Annotation [](id=insert-the-component-annotation)
+### Insert the @Component Annotation [](id=insert-the-component-annotation)
 
 Directly above the class's declaration, insert the following annotation:
 
@@ -93,7 +93,7 @@ a `panel.category.order:Integer` of 150.
 
 $$$
 
-### Implement the `PanelCategory` Interface [](id=implement-the-panelcategory-interface)
+### Implement the PanelCategory Interface [](id=implement-the-panelcategory-interface)
 
 The `PanelCategory` interface requires you to implement the following methods:
 


### PR DESCRIPTION
We shouldn't use the tick marks for the headers of sections because it makes the formatting inconsistent and looks strange with the rest of the content. 

Reference: https://dev.liferay.com/develop/tutorials/-/knowledge_base/7-1/adding-custom-panel-categories

![image](https://user-images.githubusercontent.com/20053436/53117665-44ad7000-3500-11e9-92b6-357670c178c2.png)
![image](https://user-images.githubusercontent.com/20053436/53117677-4a0aba80-3500-11e9-9ea4-d49dcb1b6d4a.png)
