### PR TITLE
LRDOCS-6316 7.0: Overriding and aggregating resource bundles using OSGi headers

### DIFF
--- a/develop/tutorials/articles/111-customizing/05-overriding-language-keys.markdown
+++ b/develop/tutorials/articles/111-customizing/05-overriding-language-keys.markdown
@@ -195,7 +195,7 @@ Here is the process:
 
 1.  [Find the module and its metadata and language keys](#find-the-module-and-its-metadata-and-language-keys)
 2.  [Write your custom language key values](#providing-language-keys) 
-3.  [Implement a Resource Bundle Loader](#implementing-a-resource-bundle-loader)
+3.  [Prioritize your module's resource bundle](#prioritize-your-modules-resource-bundle)
 
 ### Find the module and its metadata and language keys [](id=find-the-module-and-its-metadata-and-language-keys)
 
@@ -286,166 +286,68 @@ In your module's `src/main/resources/content` folder, create
 for each locale whose keys you want to override. In each language properties
 file, specify your language key overrides. 
 
-Next you'll create a resource bundle loader component to apply the language keys
-to the target module. 
+Next you'll prioritize your module's language keys as a resource bundle for the
+target module. 
 
-### Implement a resource bundle loader [](id=implementing-a-resource-bundle-loader)
+## Prioritize Your Module's Resource Bundle [](id=prioritize-your-modules-resource-bundle)
 
-In this step, you'll create a resource bundle loader component that combines
-your new resource bundle containing the new language key values with the target
-module's existing resource bundle. The new language key values are combined so
-they override the old ones. 
+Now that your language keys are in place, use OSGi manifest headers to specify
+the language keys are for the target module. To compliment the target module's
+resource bundle, you'll aggregate your resource bundle with the target module's
+resource bundle. You'll list your module first to prioritize its resource bundle
+over the target module resource bundle.  Here's an example of module
+`com.liferay.docs.l10n.myapp.lang` prioritizing its resource bundle over target
+module `com.liferay.blogs.web`'s resource bundle:
 
-For example, the following resource bundle loader component combines the current
-bundle's language keys with the `com.liferay.blogs.web` module's language keys
-and applies them to the `com.liferay.blogs.web` module. 
+    Provide-Capability:\
+    liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+    liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang),(bundle.symbolic.name=com.liferay.blogs.web)";bundle.symbolic.name=com.liferay.blogs.web;resource.bundle.base.name="content.Language";service.ranking:Long="2";\
+    servlet.context.name=blogs-web
 
-    @Component(
-    	immediate = true,
-    	property = {
-    		"bundle.symbolic.name=com.liferay.blogs.web",
-    		"resource.bundle.base.name=content.Language",
-    		"servlet.context.name=blogs-web"
-    	}
-    )
-    public class MyBlogsResourceBundleLoader implements ResourceBundleLoader {
+Let's examine the example `Provide-Capability` header. 
 
-    	@Override
-    	public ResourceBundle loadResourceBundle(Locale locale) {
-    		return _resourceBundleLoader.loadResourceBundle(locale);
-    	}
+1.  `liferay.resource.bundle;resource.bundle.base.name="content.Language"` 
+    declares that the module provides a resource bundle whose base name is
+    `content.language`. 
 
-    	@Reference(
-    		target = "(&(bundle.symbolic.name=com.liferay.blogs.web)(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
-    	)
-    	public void setResourceBundleLoader(
-    		ResourceBundleLoader resourceBundleLoader) {
+2.  The `liferay.resource.bundle;resource.bundle.aggregate:String=...` directive
+    specifies the list of bundles whose resource bundles are aggregated, the
+    target bundle, the target bundle's resource bundle name, and this service's
+    ranking:
 
-    		_resourceBundleLoader = new AggregateResourceBundleLoader(
-    			new CacheResourceBundleLoader(
-    				new ClassResourceBundleLoader(
-    					"content.Language",
-    					MyBlogsResourceBundleLoader.class.getClassLoader())),
-    			resourceBundleLoader);
-    	}
+    -   `"(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang),(bundle.symbolic.name=com.liferay.blogs.web)"`:
+        The service aggregates resource bundles from bundles
+        `com.liferay.docs.l10n.myapp.lang` and `com.liferay.blogs.web`.
+        Aggregate as many bundles as desired. Listed bundles are prioritized in
+        descending order. 
+    -   `bundle.symbolic.name=com.liferay.blogs.web;resource.bundle.base.name="content.Language"`:
+        Override the `com.liferay.blogs.web` bundle's resource bundle named
+        `content.Language`.
+    -   `service.ranking:Long="2"`: The resource bundle's service ranking is 
+        `2`. The OSGi framework applies this service if it outranks all other
+        resource bundle services that target `com.liferay.blogs.web`'s
+        `content.Language` resource bundle. 
+    -   `servlet.context.name=blogs-web`: The target resource bundle is in 
+        servlet context `blogs-web`. 
 
-    	private AggregateResourceBundleLoader _resourceBundleLoader;
-
-    }
-
-This class implements
-[`com.liferay.portal.kernel.util.ResourceBundleLoader`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/ResourceBundleLoader.html)
-and overrides all its methods. 
-
-The `@Component` annotation registers the class as a resource bundle loader component
-for the target module. The example's target module has the bundle symbolic name
-`com.liferay.blogs.web` and servlet context `blogs-web`. Liferay's modules use a
-base resource bundle named `content.Language`. Attribute setting `immediate =
-true` tells the OSGi framework to activate the component immediately after its
-dependencies resolve.
-
-    @Component(
-    	immediate = true,
-    	property = {
-    		"bundle.symbolic.name=com.liferay.blogs.web",
-    		"resource.bundle.base.name=content.Language",
-    		"servlet.context.name=blogs-web"
-    	}
-    )
-
-Write your `@Component` annotation similarly, making sure to apply the bundle
-symbolic name and servlet context name you recorded earlier to the following
-properties:
-
--   `"bundle.symbolic.name=[target module bundle symbolic name]"`
--   `"servlet.context.name=[target module servlet context name]"`
-
-The class's resource bundle loader field `_resourceBundleLoader` field is an
-`AggregateResourceBundleLoader` for grouping this resource bundle loader and the
-target module's resource bundle loader together. 
-
-    private AggregateResourceBundleLoader _resourceBundleLoader;
-
-The `loadResourceBundle` methods return a resource bundle based on the locale. 
-
-    @Override
-    public ResourceBundle loadResourceBundle(Locale locale) {
-        return _resourceBundleLoader.loadResourceBundle(locale);
-    }
+[Deploy your module](/develop/tutorials/-/knowledge_base/7-0/starting-module-development#building-and-deploying-a-module)
+to see the language keys you've overridden. 
 
 +$$$
 
-**Note**: As of Liferay DXP Digital Experience Fix Pack de-33 and Liferay Portal
-CE GA6, `ResourceBundleLoader` method `loadResourceBundle(String)` is deprecated
-and replaced by new method `loadResourceBundle(Locale)`.
+**Tip:** If your override isn't showing, use
+[Gogo Shell](/develop/reference/-/knowledge_base/7-0/using-the-felix-gogo-shell)
+to check for competing resource bundle services. It may be that another service
+outranks yours. To check for competing resource bundle services whose aggregates
+include `com.liferay.blogs.web`'s resource bundle, for example, execute this
+Gogo Shell command:
+
+    services "(bundle.symbolic.name=com.liferay.login.web)"
+
+Search the results for resource bundle aggregate services whose ranking is
+higher. 
 
 $$$
-
-The setter method `setResourceBundleLoader` assigns an aggregate of this class's
-resource bundle loader and the target resource bundle loader to the
-`_resourceBundleLoader` field. 
-        
-    @Reference(target = "(bundle.symbolic.name=com.liferay.blogs.web)(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
-    )
-    public void setResourceBundleLoader(
-        ResourceBundleLoader resourceBundleLoader) {
-
-        _resourceBundleLoader = new AggregateResourceBundleLoader(
-            new CacheResourceBundleLoader(
-                new ClassResourceBundleLoader(
-                    "content.Language",
-                    MyBlogsResourceBundleLoader.class.getClassLoader())),
-            resourceBundleLoader);
-    }
-
-The `@Reference` annotation tells @product@'s OSGi framework to pass the target
-module's resource bundle loader as the parameter. Specifying the target module
-is tricky because the target module and the resource bundle loader component
-have the same bundle symbolic name property
-(`bundle.symbolic.name=com.liferay.blogs.web`). To prevent this resource bundle
-loader component from being targeted, specify an `!` (not) character followed by
-this resource bundle loader's `component.name` property. 
-
-The method creates a resource bundle loader that aggregates this module's
-resource bundle loader and the target module's resource bundle loader. The first
-loader's resource bundle is prioritized ahead of the resource bundles that
-follow it. Therefore, this class's resource bundle loader and its resource
-bundle (i.e., language keys), take precedence.
-
-If you use the example `setResourceBundleLoader` method, make sure to replace
-`MyBlogsResourceBundleLoader` with your resource bundle loader's class name. 
-
-Resource bundle loader components have these class imports.
-
-    import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
-    import com.liferay.portal.kernel.util.CacheResourceBundleLoader;
-    import com.liferay.portal.kernel.util.ClassResourceBundleLoader;
-    import com.liferay.portal.kernel.util.ResourceBundleLoader;
-
-    import java.util.ResourceBundle;
-
-    import org.osgi.service.component.annotations.Component;
-    import org.osgi.service.component.annotations.Reference;
-
-You can
-[depend on packages from the following artifacts](/develop/tutorials/-/knowledge_base/7-0/configuring-dependencies)
-to provide the classes imported above.
-
- Group | Artifact |
- :------ | :------ |
-`com.liferay.portal` | `com.liferay.portal.kernel` |
- `org.osgi` | `org.osgi.service.component.annotations` | 
-
- **Important**: If your module
- [uses language keys from another module](/develop/tutorials/-/knowledge_base/7-0/localizing-your-application#using-a-language-module)
- and
- [overrides any of that other module's keys](/develop/tutorials/-/knowledge_base/7-0/localizing-your-application#using-a-language-module-from-a-module),
- make sure to use OSGi headers to specify the capabilities your module requires
- and provides. This lets you prioritize resource bundles from the modules. 
-
- To see your language key overrides in action,
- [deploy your module](/develop/tutorials/-/knowledge_base/7-0/starting-module-development#building-and-deploying-a-module)
- and visit a portlet that uses the module's language keys. 
 
 Now you can modify the language keys of modules in Liferay's OSGi runtime.
 Remember, language keys you want to override might actually be in Liferay's

--- a/develop/tutorials/articles/220-internationalization/01-localizing-your-application.markdown
+++ b/develop/tutorials/articles/220-internationalization/01-localizing-your-application.markdown
@@ -129,11 +129,11 @@ application with multiple modules that provide the view layer. These modules are
 often called web modules.
 
     my-application/
-        my-application-web/
-        my-admin-application-web/
-        my-application-content-web/
-        my-application-api/
-        my-application-service/
+    my-application-web/
+    my-admin-application-web/
+    my-application-content-web/
+    my-application-api/
+    my-application-service/
 
 Each of these modules can have language keys and translations to maintain, and
 there will probably be duplicate keys. You don't want to end up with different
@@ -192,13 +192,13 @@ module and optionally include its own resource bundle. OSGi manifest headers
 especially easy in modules generated from Liferay project templates.
 Instructions for using a language module are divided into these environments:
 
--  [Modules generated from Liferay project templates](#using-a-language-module-from-a-module)
--  [Traditional plugins or modules that don't use Liferay's bnd plugin](#using-a-language-module-from-a-traditional-plugin)
+-  [Using a Language Module from a Module](#using-a-language-module-from-a-module)
+-  [Using a Language Module from a Traditional Plugin](#using-a-language-module-from-a-traditional-plugin)
 
 If you're using bnd with Maven or Gradle, you need only specify Liferay's
 `-liferay-aggregate-resource-bundle:` bnd instruction--at build time, Liferay's
 bnd plugin converts the instruction to `Require-Capability` and
-`Provide-Capability` parameters automatically. Both approaches are demonstrated. 
+`Provide-Capability` parameters automatically. Both approaches are demonstrated.
 
 ### Using a Language Module from a Module [](id=using-a-language-module-from-a-module)
 
@@ -210,7 +210,8 @@ Here's how to do it:
 1.  Open your module's `bnd.bnd` file.
 
 2.  Add the `-liferay-aggregate-resource-bundles:` bnd instruction and assign it
-    the bundle symbolic names of modules whose resource bundles to use. 
+    the bundle symbolic names of modules whose resource bundles to aggregate
+    with the current module's resource bundle. 
 
         -liferay-aggregate-resource-bundles: \
             [bundle.symbolic.name1],\
@@ -224,13 +225,13 @@ would set this in its `bnd.bnd` file:
         com.liferay.docs.l10n.myapp1.lang,\
         com.liferay.docs.l10n.myapp2.lang
 
-The current module's language keys are prioritized over those from the other
-modules.  
+The current module's resource bundle is prioritized over those of the listed
+modules. 
 
 +$$$
 
 The
-[Shared Language Key sample project](/develop/reference/-/knowledge_base/7-0/shared-language-keys)
+[Shared Language Key sample project](/develop/reference/-/knowledge_base/7-1/shared-language-keys)
 is a working example that demonstrates aggregating resource bundles. You can
 deploy it in Gradle, Maven, and Liferay Workspace build environments. 
 
@@ -239,6 +240,13 @@ $$$
 At build time, Liferay's bnd plugin converts the bnd instruction to
 `Require-Capability` and `Provide-Capability` parameters automatically. In
 traditional Liferay plugins, you must specify the parameters manually. 
+
++$$$
+
+**Note:** You can always specify the `Require-Capability` and `Provide-
+Capability` OSGi manifest headers manually, as the next section demonstrates.  
+
+$$$
 
 ### Using a Language Module from a Traditional Plugin [](id=using-a-language-module-from-a-traditional-plugin)
 
@@ -252,63 +260,64 @@ module:
 1.  Open the plugin's `liferay-plugin-package.properties` file and add a 
     `Require-Capability` header that filters on the language module's resource
     bundle capability. For example, if the language module's symbolic name is
-    `com.liferay.docs.l10n.myapp.lang`, you'd specify the requirement like this:
+    `myapp.lang`, you'd specify the requirement like this:
 
-        Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)"
+        Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=myapp.lang)"
 
 2.  In the same `liferay-plugin-package.properties` file, add a 
     `Provide-Capability` header that adds the language module's resource bundle
-    *as* this plugin's own resource bundle:
+    *as* this plugin's (the `myapp.web` plugin) own resource bundle:
 
-        Provide-Capability: liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";resource.bundle.base.name="content.Language"
+        Provide-Capability:\
+        liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+        liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=myapp.lang)";bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language";service.ranking:Long="4";\
+        servlet.context.name=myapp-web
 
-In this case, the plugin solely uses the language module's resource bundle. 
+In this case, the `myapp.web` plugin solely uses the language module's resource
+bundle---the resource bundle aggregate only includes language module
+`myapp.lang`. 
 
-Aggregating resource bundles comes into play when you want to use your plugin's
-resource bundle *in addition to* a resource bundle from a module. These
-instructions show you how to do this, while prioritizing your plugin's resource
-bundle over the module resource bundle. In this way, the module's language keys
-compliment your plugin's language keys. 
+Aggregating resource bundles comes into play when you want to use your a
+language module's resource bundle *in addition to* your plugin's resource
+bundle. These instructions show you how to do this, while prioritizing your
+current plugin's resource bundle over the language module resource bundle. In
+this way, the language module's language keys compliment your plugin's language
+keys. 
 
-For example, a portlet whose bundle symbolic name is `my-portlet` uses
-keys from language module `com.liferay.docs.l10n.myapp.lang`, but overrides some
-of them. The portlet's `Provide-Capability` and `Web-ContextPath` OSGi
-headers accomplish this.
+For example, a portlet whose bundle symbolic name is `myapp.web` uses keys from
+language module `myapp.lang`, in addition to its own. The portlet's
+`Provide-Capability` and `Web-ContextPath` OSGi headers accomplish this.
 
     Provide-Capability:\
-    liferay.resource.bundle;resource.bundle.base.name:String="(bundle.symbolic.name=my-portlet)";resource.bundle.base.name="content.Language",\
-    liferay.resource.bundle;resource.bundle.aggregate:String="(&(bundle.symbolic.name=my-portlet)(!(aggregate=true))),(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";bundle.symbolic.name=my-portlet;resource.bundle.base.name="content.Language";service.ranking:Long="1";aggregate=true;\
-    servlet.context.name=my-admin-application-web
+    liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+    liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=myapp.web),(bundle.symbolic.name=myapp.lang)";bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language";service.ranking:Long="4";\
+    servlet.context.name=myapp-web
 
-    Web-ContextPath:/my-admin-application-web
+Let's examine the example `Provide-Capability` header. 
 
-Each line is explained:
+1.  `liferay.resource.bundle;resource.bundle.base.name="content.Language"` 
+    declares that the module provides a resource bundle whose base name is
+    `content.language`. 
 
-1.  The first `Provide-Capability` line declares the portlet's resource
-    bundle. This portlet's bundle symbolic name is
-    `my-portlet`. 
+2.  The `liferay.resource.bundle;resource.bundle.aggregate:String=...` directive
+    specifies the list of bundles whose resource bundles are aggregated, the
+    target bundle, the target bundle's resource bundle name, and this service's
+    ranking:
 
-        liferay.resource.bundle;resource.bundle.base.name:String="(bundle.symbolic.name=my-portlet)";resource.bundle.base.name="content.Language",\
-
-2.  The second `Provide-Capability` line aggregates the portlet resource
-    bundle and the language module resource bundle, prioritizing the portlet
-    resource bundle over the language module resource bundle. The last part of
-    this capability declares the module's servlet context name. 
-
-        liferay.resource.bundle;resource.bundle.aggregate:String="(&(bundle.symbolic.name=my-portlet)(!(aggregate=true))),(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";bundle.symbolic.name=my-portlet;resource.bundle.base.name="content.Language";service.ranking:Long="1";aggregate=true;\
-        servlet.context.name=my-admin-application-web
-
-3.  The `Web-ContextPath` header declares the portlet's web context path.
-    @product@ uses the web context path and the servlet context declared in
-    the `Provide-Capability` header to make the aggregated resource bundle
-    available to the portlet's JSPs automatically.
-
-        Web-ContextPath:/my-admin-application-web
-
-To aggregate web module keys and language module keys, follow the pattern
-demonstrated by the example above. The example language module and web modules
-can be downloaded 
-[here](https://dev.liferay.com/documents/10184/656312/l10n-my-application.zip/3bf58646-95ba-4031-bd1a-ce52cc6152f3). 
+    -   `"(bundle.symbolic.name=myapp.web),(bundle.symbolic.name=myapp.lang)"`:
+        The service aggregates resource bundles from bundles
+        `bundle.symbolic.name=myapp.web` (the current module) and
+        `bundle.symbolic.name=myapp.lang`. Aggregate as many bundles as desired.
+        Listed bundles are prioritized in descending order. 
+    -   `bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language"`:
+        Override the `myapp.web` bundle's resource bundle named
+        `content.Language`.
+    -   `service.ranking:Long="4"`: The resource bundle's service ranking is 
+        `4`. The OSGi framework applies this service if it outranks all other
+        resource bundle services that target `myapp.web`'s `content.Language`
+        resource bundle. 
+    -   `servlet.context.name=myapp-web`: The target resource bundle is in 
+        servlet context `myapp-web`. 
 
 Now the language keys from the aggregated resource bundles compliment your
 plugin's language keys.


### PR DESCRIPTION
Resource bundle loaders are no longer needed for overriding language keys; OSGi manifest headers let you do everything. The articles on overriding language keys and using language keys are updated.
https://issues.liferay.com/browse/LRDOCS-6316