### PR TITLE
Example code didn't render expected html

### DIFF
--- a/develop/tutorials/articles/03-developing-a-web-application/02-creating-working-prototype/06-creating-a-form.markdown
+++ b/develop/tutorials/articles/03-developing-a-web-application/02-creating-working-prototype/06-creating-a-form.markdown
@@ -10,7 +10,8 @@ entry itself.
 
 Add the following tags to the end of your `edit_entry.jsp` file: 
 
-    <aui:form action="<%= addEntryURL %>" name="<portlet:namespace />fm">
+    <c:set var="portletNamespace"><portlet:namespace/></c:set>
+    <aui:form action="<%= addEntryURL %>" name="${portletNamespace}fm">
             <aui:fieldset>
                 <aui:input name="name"></aui:input>
                 <aui:input name="message"></aui:input>


### PR DESCRIPTION
> portletNamespace was not reflecting in page properly

`<portlet:namespace/>` was prepended instead of dynamically generating the actual portlet's namespace and then prepending the actual value