### PR TITLE
removed getEntry method call in deleteEntry method impl

### DIFF
--- a/develop/tutorials/articles/04-developing-a-web-application/03-generating-the-backend/03-implementing-service-methods.markdown
+++ b/develop/tutorials/articles/04-developing-a-web-application/03-generating-the-backend/03-implementing-service-methods.markdown
@@ -186,9 +186,7 @@ Do so now by following these steps:
         public Entry deleteEntry (long entryId, ServiceContext serviceContext)
             throws PortalException {
 
-            Entry entry = getEntry(entryId);
-
-            entry = deleteEntry(entryId);
+            Entry entry = deleteEntry(entryId);
 
             return entry;
         }


### PR DESCRIPTION
Both getEntry(entryId) and deleteEntry(entryId) return the entity by its ID or throw a PortalException
if the entity with the provided Id does not exists in the persistence layer. So, the call to getEntry is redundant.
The method implementation could have been simplified to one-line: return deleteEntry(entryId), but
I keep the assigment to make it more clear that deleteEntry() method is returning the Entry.