### PR TITLE
Broken  link to lexiconcss at wedeploy.

### DIFF
--- a/develop/tutorials/articles/110-portlets/20-lexicon/07-using-lexicon-icons-in-your-app.markdown
+++ b/develop/tutorials/articles/110-portlets/20-lexicon/07-using-lexicon-icons-in-your-app.markdown
@@ -9,7 +9,7 @@ header-id: using-lexicon-icons-in-your-app
 Whether you're updating your app to @product-ver@ or writing a new 
 @product-ver@ app, follow the process here to use Lexicon's icons. 
 You can find the list of available Lexicon icons on the 
-[Lexicon site](https://lexiconcss.wedeploy.io/content/icons-lexicon/).
+[Lexicon site](https://liferay.github.io/lexiconcss/content/icons-lexicon/).
 
 Lexicon icons are defined with the `icon` attribute. For example, you define the
 icon in the management bar, inside the


### PR DESCRIPTION
Changed to lexiconcss github pages.