### PR TITLE
Typo in resources folder path

### DIFF
--- a/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
+++ b/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
@@ -83,7 +83,7 @@ Next you need to include the fragments that you want to contribute in your
 module:
 
 1.  In your module's `resources/` folder, create the folder structure
-    `/com/liferay/fragments/collection/contributor/demo/dependencies`.
+    `/com/liferay/fragment/collection/contributor/demo/dependencies`.
 
 2.  Copy the Fragments you want to distribute into the folder. You can learn 
     how to create a Fragment in the


### PR DESCRIPTION
The path must be the same as Contributor package otherwise, it won't work without printing any error