### PR TITLE
Fix grammar and typo errors in "Creating the AlloyEditor Button’s OSGi Bundle" page

### DIFF
--- a/en/develop/tutorials/articles/320-wysiwyg-editors/04-alloy-editor/02-creating-new-buttons-for-alloyeditor/01-creating-the-buttons-osgi-bundle.markdown
+++ b/en/develop/tutorials/articles/320-wysiwyg-editors/04-alloy-editor/02-creating-new-buttons-for-alloyeditor/01-creating-the-buttons-osgi-bundle.markdown
@@ -59,8 +59,8 @@ Follow these steps to create your OSGi bundle for your new button:
           "version": "1.0.0"
         }
 
-6.  Add following preset to your module's `.babelc` file to transpile your JSX 
-    file:
+6.  Add the following preset to your module's `.babelrc` file to transpile your 
+    JSX file:
 
         {
           "presets": [


### PR DESCRIPTION
This fixes Step 6 in the [Creating the AlloyEditor Button’s OSGi Bundle](https://portal.liferay.dev/docs/7-1/tutorials/-/knowledge_base/t/creating-the-alloyeditor-buttons-osgi-bundle) page.