### PR TITLE
Added note about osgi.web.symbolicname value

### DIFF
--- a/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
+++ b/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
@@ -74,6 +74,7 @@ contributed collection:
         target = "(osgi.web.symbolicname=com.liferay.fragment.collection.contributor.demo)"
     )
     ```
+    | **Note:** `osgi.web.symbolicname` must match `Bundle-SymbolicName` from `bnd.bnd`
 
 7.  Organize your imports and save.
 


### PR DESCRIPTION
The relation between osgi.web.symbolicname and Bundle-SymbolicName is not straightforward, especially for the beginners who may lose hours trying to figure out why their Collection is not appearing in the editor, while the bundle is properly activated and there are no errors in the console. I think it should be clearly stated they must be the same.