### PR TITLE
Fixed typo in npmbundler documentation

### DIFF
--- a/en/developer/reference/articles/02-front-end/04-liferay-npm-bundler/03-npmbundlerrc-structure.markdown
+++ b/en/developer/reference/articles/02-front-end/04-liferay-npm-bundler/03-npmbundlerrc-structure.markdown
@@ -98,19 +98,7 @@ Here's an example of a `.npmbundlerrc` configuration:
       ]
     },
     "packages": {
-        "a-package-name": [
-        "copy-plugins": ["exclude-imports"],
-        "plugins": ["replace-browser-modules"],
-        ".babelrc": {
-          "presets": ["liferay-standard"]
-        },
-        "post-plugins": [
-          "namespace-packages",
-          "inject-imports-dependencies",
-          "inject-peer-dependencies"
-        ]
-        ],
-        "other-package-name@1.0.10": [
+        "a-package-name": {
           "copy-plugins": ["exclude-imports"],
           "plugins": ["replace-browser-modules"],
           ".babelrc": {
@@ -121,7 +109,19 @@ Here's an example of a `.npmbundlerrc` configuration:
             "inject-imports-dependencies",
             "inject-peer-dependencies"
           ]
-        ]
+        },
+        "other-package-name@1.0.10": {
+          "copy-plugins": ["exclude-imports"],
+          "plugins": ["replace-browser-modules"],
+          ".babelrc": {
+            "presets": ["liferay-standard"]
+          },
+          "post-plugins": [
+            "namespace-packages",
+            "inject-imports-dependencies",
+            "inject-peer-dependencies"
+          ]
+        }
     }
 }
 ```


### PR DESCRIPTION
This PR fixes a typo in the npm bundler documentation, which is incorrectly using JSON array syntax to describe a JSON object. (see at https://help.liferay.com/hc/en-us/articles/360028832872-Understanding-the-npmbundlerrc-s-Structure)