### PR TITLE
03-accessing-google-docs.markdown replaced TM character

### DIFF
--- a/discover/portal/articles/110-collaboration/01-managing-documents-and-media/01-publishing-files/03-accessing-google-docs.markdown
+++ b/discover/portal/articles/110-collaboration/01-managing-documents-and-media/01-publishing-files/03-accessing-google-docs.markdown
@@ -2,7 +2,7 @@
 header-id: accessing-google-docs
 ---
 
-# Accessing Google Docs&trade;
+# Accessing Google Docs™
 
 [TOC levels=1-4]
 


### PR DESCRIPTION
Instead of &trade; to indicate the trade character, I added the character itself to see if it would work.